### PR TITLE
Fix Click NavBar & TitleBarBtns

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -27,7 +27,8 @@ const Item = styled.div<{ active?: boolean }>`
 	justify-content: center;
 	flex-flow: column;
 	padding: .25rem;
-	cursor: pointer;
+  cursor: pointer;
+  -webkit-app-region: no-drag;
 	
 	${props => props.active && css`
 		cursor: default;

--- a/src/components/TitleBarBtns.tsx
+++ b/src/components/TitleBarBtns.tsx
@@ -27,6 +27,7 @@ const StyledDiv = styled.div<{ purple?: boolean }>`
 	align-items: center;
 	justify-content: center;
 	user-select: none;
+	-webkit-app-region: no-drag;
 	filter: grayscale(100%) brightness(125%);
 	animation: all .3s ease;
 	${window.process.platform === 'darwin' && css`background-color: #0075eb;`}


### PR DESCRIPTION
Fix problem when user try to click on any buttons of the Navbar or TitlesBarBtns because the drag cursor appear and move the window instead of trigger the event button. [Fedora 29].