### PR TITLE
Fix crashing the app when choosing attachement is cancelled

### DIFF
--- a/src/screens/Chats.tsx
+++ b/src/screens/Chats.tsx
@@ -108,6 +108,10 @@ export const Chats = () => {
 
     console.log({ result });
 
+    if (!result.filePaths[0]) { // handle cancel clicked
+      return;
+    }
+
     const file = fs.readFileSync(result.filePaths[0]);
 
     const formData = new FormData();


### PR DESCRIPTION
The app crashes when you click cancel button during choosing attachement (at least on macOS Catalina) 