### PR TITLE
Show menu bar on macOS

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -1,7 +1,12 @@
 const {app, BrowserWindow, Menu} = require("electron");
 const path = require("path");
 let mainWindow;
-Menu.setApplicationMenu(false);
+
+// hide menu bar on systems other than macOS
+// on macOS we have to show it to allow copy, paste and other default system actions
+if (process.platform !== 'darwin') {
+  Menu.setApplicationMenu(null);
+}
 
 process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = true;
 


### PR DESCRIPTION
When menu bar is disabled on macOS it's not possible to copy, paste etc. I suppose it was disabled because it looked ugly on other OS. On macOS it doesn't look bad because menu bar is included in top bar - see screenshot:

<img width="892" alt="Screenshot 2020-04-19 at 10 44 02" src="https://user-images.githubusercontent.com/4882750/79683968-20e1d900-822e-11ea-8bac-5daf2bb1e55a.png">
